### PR TITLE
47 エラーのときにウィンドウを表示しない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.o
-cub3d
+cub3D
 *.a
 minilibx-linux/test/mlx-test

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,6 @@ norm:
 	norminette srcs includes
 
 valgrind: all
-	valgrind --leak-check=full --show-leak-kinds=all ./cub3d maps/test.cub
+	valgrind --leak-check=full --show-leak-kinds=all ./cub3D maps/has_space_map.cub
 
 .PHONY: all clean fclean re norm valgrind

--- a/maps/has_space_map.cub
+++ b/maps/has_space_map.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../textures/book_shell.xpm
-EA ../textures/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 220,100,0
 C 225,30,0

--- a/maps/invalid.cub
+++ b/maps/invalid.cub
@@ -1,7 +1,7 @@
-NO ./textures/nonfile
-SO ./textures/test.xpm
-WE ./textures/test.xpm
-EA ./textures/test.xpm
+NO textures/nonfile
+SO textures/test.xpm
+WE textures/test.xpm
+EA textures/test.xpm
 
 F 220,100,0
 C 225,30,0

--- a/maps/invalid_color_format.cub
+++ b/maps/invalid_color_format.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 255,30,0
 C 200,100,0

--- a/maps/invalid_color_format_10.cub
+++ b/maps/invalid_color_format_10.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C
 F 255,30,0

--- a/maps/invalid_color_format_11.cub
+++ b/maps/invalid_color_format_11.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 255,30,0
 F 255,30,13123901`87486487832792399

--- a/maps/invalid_color_format_2.cub
+++ b/maps/invalid_color_format_2.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 F 255,30,0
 C 0,0,0
 

--- a/maps/invalid_color_format_3.cub
+++ b/maps/invalid_color_format_3.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 255,30,0
 

--- a/maps/invalid_color_format_4.cub
+++ b/maps/invalid_color_format_4.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 255,30,0
 C 255,30,0

--- a/maps/invalid_color_format_5.cub
+++ b/maps/invalid_color_format_5.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 255,30,0
 F 255,30,0

--- a/maps/invalid_color_format_6.cub
+++ b/maps/invalid_color_format_6.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 256,30,0
 F 255,30,0

--- a/maps/invalid_color_format_7.cub
+++ b/maps/invalid_color_format_7.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F -1,30,0
 F 255,30,0

--- a/maps/invalid_color_format_8.cub
+++ b/maps/invalid_color_format_8.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 251,30
 F 255,30,0

--- a/maps/invalid_color_format_9.cub
+++ b/maps/invalid_color_format_9.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 251
 F 255,30,0

--- a/maps/invalid_map_format.cub
+++ b/maps/invalid_map_format.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 11111
 1N001

--- a/maps/invalid_map_format_2.cub
+++ b/maps/invalid_map_format_2.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 
 C 200,100,0

--- a/maps/invalid_map_format_3.cub
+++ b/maps/invalid_map_format_3.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 200,100,0
 C 200,100,0

--- a/maps/invalid_map_format_4.cub
+++ b/maps/invalid_map_format_4.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 200,100,0
 C 200,100,0

--- a/maps/invalid_map_format_5.cub
+++ b/maps/invalid_map_format_5.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 200,100,0
 F 200,100,0

--- a/maps/invalid_map_format_6.cub
+++ b/maps/invalid_map_format_6.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 200,100,0
 F 200,100,0

--- a/maps/invalid_map_format_7.cub
+++ b/maps/invalid_map_format_7.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 200,100,0
 F 200,100,0

--- a/maps/invalid_map_format_8.cub
+++ b/maps/invalid_map_format_8.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 C 200,100,0
 F 200,100,0

--- a/maps/invalid_texture_format.cub
+++ b/maps/invalid_texture_format.cub
@@ -1,8 +1,8 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 255,30,0
 C 200,100,0

--- a/maps/invalid_texture_format_2.cub
+++ b/maps/invalid_texture_format_2.cub
@@ -1,9 +1,9 @@
 F 255,30,0
 C 200,100,0
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 11111
 1N001

--- a/maps/invalid_texture_format_3.cub
+++ b/maps/invalid_texture_format_3.cub
@@ -1,9 +1,9 @@
 F 255,30,0
 C 200,100,0
 
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
 
 11111
 1N001

--- a/maps/invalid_texture_format_4.cub
+++ b/maps/invalid_texture_format_4.cub
@@ -2,9 +2,9 @@ F 255,30,0
 C 200,100,0
 
 NO
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 11111
 1N001

--- a/maps/invalid_texture_format_5.cub
+++ b/maps/invalid_texture_format_5.cub
@@ -1,10 +1,10 @@
 F 255,30,0
 C 200,100,0
 
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-NO ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+NO textures/book_shell.xpm
 
 11111
 1N001

--- a/maps/invalid_texture_format_6.cub
+++ b/maps/invalid_texture_format_6.cub
@@ -1,10 +1,10 @@
 F 255,30,0
 C 200,100,0
 
-SO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+SO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 11111
 1N001

--- a/maps/invalid_texture_format_7.cub
+++ b/maps/invalid_texture_format_7.cub
@@ -1,10 +1,10 @@
 F 255,30,0
 C 200,100,0
 
-NO ../textures/book_shell.xpm
-WE ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+WE textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 11111
 1N001

--- a/maps/invalid_texture_format_8.cub
+++ b/maps/invalid_texture_format_8.cub
@@ -1,10 +1,10 @@
 F 255,30,0
 C 200,100,0
 
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-EA ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+EA textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 11111
 1N001

--- a/maps/invalid_texture_format_9.cub
+++ b/maps/invalid_texture_format_9.cub
@@ -1,9 +1,9 @@
 F 255,30,0
 C 200,100,0
 
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+EA textures/book_shell.xpm
 WE
 
 11111

--- a/maps/mini.cub
+++ b/maps/mini.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../texture/book_shell.xpm
-EA ../texture/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 255,30,0
 C 200,100,0

--- a/maps/test.cub
+++ b/maps/test.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../textures/book_shell.xpm
-EA ../textures/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 220,100,0
 C 225,30,0

--- a/maps/test_strange.cub
+++ b/maps/test_strange.cub
@@ -1,7 +1,7 @@
-NO ../textures/book_shell.xpm
-SO ../textures/book_shell.xpm
-WE ../textures/book_shell.xpm
-EA ../textures/book_shell.xpm
+NO textures/book_shell.xpm
+SO textures/book_shell.xpm
+WE textures/book_shell.xpm
+EA textures/book_shell.xpm
 
 F 220,100,0
 C 225,30,0

--- a/srcs/init_mlx.c
+++ b/srcs/init_mlx.c
@@ -6,7 +6,7 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/08 14:12:20 by yohatana          #+#    #+#             */
-/*   Updated: 2025/06/22 03:01:49 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/06/22 16:28:51 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,10 @@ void	init_mlx(t_mlx_data *mlx_data)
 		print_error("mlx_init failed. :(");
 		exit(EXIT_FAILURE);
 	}
+	load_texture(mlx_data, &mlx_data->north_tex, map_data->north_path);
+	load_texture(mlx_data, &mlx_data->south_tex, map_data->south_path);
+	load_texture(mlx_data, &mlx_data->west_tex, map_data->west_path);
+	load_texture(mlx_data, &mlx_data->east_tex, map_data->east_path);
 	mlx_data->win = mlx_new_window(mlx_data->mlx, WIDTH, HEIGHT, WINDOW_NAME);
 	if (!mlx_data->win)
 	{
@@ -32,10 +36,6 @@ void	init_mlx(t_mlx_data *mlx_data)
 		print_error("mlx_new_windows failed. :(");
 		exit(EXIT_FAILURE);
 	}
-	load_texture(mlx_data, &mlx_data->north_tex, map_data->north_path);
-	load_texture(mlx_data, &mlx_data->south_tex, map_data->south_path);
-	load_texture(mlx_data, &mlx_data->west_tex, map_data->west_path);
-	load_texture(mlx_data, &mlx_data->east_tex, map_data->east_path);
 }
 
 static void	load_texture(t_mlx_data *mlx_data, t_texture *tex, char *path)

--- a/srcs/init_mlx.c
+++ b/srcs/init_mlx.c
@@ -6,7 +6,7 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/08 14:12:20 by yohatana          #+#    #+#             */
-/*   Updated: 2025/06/22 16:32:26 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/06/22 16:35:44 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ void	init_mlx(t_mlx_data *mlx_data)
 	{
 		mlx_destroy_display(mlx_data->mlx);
 		free(mlx_data->mlx);
+		clean_map_data(mlx_data->map_data);
 		exit_error("mlx_new_windows failed. :(");
 	}
 }
@@ -46,6 +47,7 @@ static void	load_texture(t_mlx_data *mlx_data, t_texture *tex, char *path)
 	{
 		mlx_destroy_display(mlx_data->mlx);
 		free(mlx_data->mlx);
+		clean_map_data(mlx_data->map_data);
 		exit_error("failed: load texture");
 	}
 	tex->img.addr = mlx_get_data_addr(

--- a/srcs/init_mlx.c
+++ b/srcs/init_mlx.c
@@ -6,7 +6,7 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/08 14:12:20 by yohatana          #+#    #+#             */
-/*   Updated: 2025/06/22 16:28:51 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/06/22 16:32:26 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,10 +21,7 @@ void	init_mlx(t_mlx_data *mlx_data)
 	map_data = mlx_data->map_data;
 	mlx_data->mlx = mlx_init();
 	if (!mlx_data->mlx)
-	{
-		print_error("mlx_init failed. :(");
-		exit(EXIT_FAILURE);
-	}
+		exit_error("mlx_init failed. :(");
 	load_texture(mlx_data, &mlx_data->north_tex, map_data->north_path);
 	load_texture(mlx_data, &mlx_data->south_tex, map_data->south_path);
 	load_texture(mlx_data, &mlx_data->west_tex, map_data->west_path);
@@ -32,9 +29,9 @@ void	init_mlx(t_mlx_data *mlx_data)
 	mlx_data->win = mlx_new_window(mlx_data->mlx, WIDTH, HEIGHT, WINDOW_NAME);
 	if (!mlx_data->win)
 	{
+		mlx_destroy_display(mlx_data->mlx);
 		free(mlx_data->mlx);
-		print_error("mlx_new_windows failed. :(");
-		exit(EXIT_FAILURE);
+		exit_error("mlx_new_windows failed. :(");
 	}
 }
 
@@ -46,7 +43,11 @@ static void	load_texture(t_mlx_data *mlx_data, t_texture *tex, char *path)
 			&tex->width,
 			&tex->height);
 	if (!tex->img.img)
+	{
+		mlx_destroy_display(mlx_data->mlx);
+		free(mlx_data->mlx);
 		exit_error("failed: load texture");
+	}
 	tex->img.addr = mlx_get_data_addr(
 			tex->img.img,
 			&tex->img.bits_per_pixel,


### PR DESCRIPTION
# Pull Request

## 概要

load_textureの位置を変更し、load_textureに失敗したときにウィンドウが一瞬表示される挙動を修正
load_textureが失敗したときに発生していたstill reachableを解消
maps/配下のテストマップの中で、textureのパスをすべて修正

## 動作確認項目

load_textureが失敗したときも、ウィンドウが表示されない
maps/のすべてのケースで、メモリリークが発生しないことを確認しました

## 補足情報

いけそう
